### PR TITLE
Change 'gen' to also return new RNG state.

### DIFF
--- a/src/WriteFut.hs
+++ b/src/WriteFut.hs
@@ -85,9 +85,9 @@ sizeIndexes n = sizeIndexes (n-1) ++ "sizes[" ++ show (n-1) ++ "] "
 -- Should not be dependent on Open Fucheck
 entryFun test rettype f =
   "entry entry_" ++ f test ++ " (size : i32) (seed : i32) : " ++ rettype ++ " =\n"
-  ++ "  let rngs = split_rng 2 <| rng_from_seed seed\n"
-  ++ "  let sizes = getsizes size rngs[0] " ++ show (numSizes test) ++ "\n"
-  ++ "  in " ++ f test ++ " (" ++ arbName test ++ sizeIndexes (numSizes test) ++ "rngs[1])"
+  ++ "  let rng = rng_from_seed seed\n"
+  ++ "  let (rng, sizes) = getsizes size rng " ++ show (numSizes test) ++ "\n"
+  ++ "  in " ++ f test ++ " (" ++ arbName test ++ sizeIndexes (numSizes test) ++ "rng).1"
 
 
 entryState test = "entry entry_" ++ stateName test ++ " : state = " ++ stateName test

--- a/src/futs/rng.fut
+++ b/src/futs/rng.fut
@@ -10,46 +10,47 @@ module Rng = {
  type rng = r.rng
 
   let snd (_,b) = b
+  let fsnd f (x, y) = (x, f y)
 
   let rng_from_seed seed = r.rng_from_seed [seed]
   let split_rng n rng = r.split_rng n rng
 
-  let rand_i64 ((low,high) : (i64,i64)) (rng : rng) : i64 =
-    snd <| dist.rand (low, high) rng
+  let rand_i64 ((low,high) : (i64,i64)) (rng : rng) : (rng, i64) =
+    dist.rand (low, high) rng
 
-  let rand_i32 ((low,high) : (i32,i32)) (rng : rng) : i32 =
-    i32.i64 <| snd <| dist.rand (i64.i32 low, i64.i32 high) rng
+  let rand_i32 ((low,high) : (i32,i32)) (rng : rng) : (rng, i32) =
+    fsnd i32.i64 <| dist.rand (i64.i32 low, i64.i32 high) rng
 
-  let rand_i16 ((low,high) : (i16,i16)) (rng : rng) : i16 =
-    i16.i64 <| snd <| dist.rand (i64.i16 low, i64.i16 high) rng
+  let rand_i16 ((low,high) : (i16,i16)) (rng : rng) : (rng, i16) =
+    fsnd i16.i64 <| dist.rand (i64.i16 low, i64.i16 high) rng
 
-  let rand_i8 ((low,high) : (i8,i8)) (rng : rng) : i8 =
-    i8.i64 <| snd <| dist.rand (i64.i8 low, i64.i8 high) rng
+  let rand_i8 ((low,high) : (i8,i8)) (rng : rng) : (rng, i8) =
+    fsnd i8.i64 <| dist.rand (i64.i8 low, i64.i8 high) rng
 
-  let rand_u64 ((low,high) : (u64,u64)) (rng : rng) : u64 =
-  let negate_high_bit bs = 0x8000000000000000 ^ bs
-  in negate_high_bit
-     <| u64.i64
-     <| snd
-     <| dist.rand ( i64.u64 (negate_high_bit low)
-                  , i64.u64 (negate_high_bit high)
-                  ) rng
+  let rand_u64 ((low,high) : (u64,u64)) (rng : rng) : (rng, u64) =
+    let negate_high_bit bs = 0x8000000000000000 ^ bs
+    in fsnd (negate_high_bit <-< u64.i64)
+       <| dist.rand ( i64.u64 (negate_high_bit low)
+                    , i64.u64 (negate_high_bit high)
+                    ) rng
 
-  let rand_u32 ((low,high) : (u32,u32)) (rng : rng) : u32 =
-    u32.i64 <| snd <| dist.rand (i64.u32 low, i64.u32 high) rng
+  let rand_u32 ((low,high) : (u32,u32)) (rng : rng) : (rng, u32) =
+    fsnd u32.i64 <| dist.rand (i64.u32 low, i64.u32 high) rng
 
-  let rand_u16 ((low,high) : (u16,u16)) (rng : rng) : u16 =
-    u16.i64 <| snd <| dist.rand (i64.u16 low, i64.u16 high) rng
+  let rand_u16 ((low,high) : (u16,u16)) (rng : rng) : (rng, u16) =
+    fsnd u16.i64 <| dist.rand (i64.u16 low, i64.u16 high) rng
 
-  let rand_u8 ((low,high) : (u8,u8)) (rng : rng) : u8 =
-    u8.i64 <| snd <| dist.rand (i64.u8 low, i64.u8 high) rng
+  let rand_u8 ((low,high) : (u8,u8)) (rng : rng) : (rng, u8) =
+    fsnd u8.i64 <| dist.rand (i64.u8 low, i64.u8 high) rng
 
-  let rand_bool ((low,high) : (bool,bool)) (rng : rng) : bool =
-    bool.i64 <| snd <| dist.rand (i64.bool low, i64.bool high) rng
+  let rand_bool ((low,high) : (bool,bool)) (rng : rng) : (rng, bool) =
+    fsnd bool.i64 <| dist.rand (i64.bool low, i64.bool high) rng
 
-  let getsizes (maxsize : size) (rng : rng) (num : i32) : [num]i32 =
-    let rngs     = r.split_rng num rng
-    let sizes    = map (\rng -> rand_i32 (0,maxsize) rng) rngs
-    in sizes
+  let getsizes (maxsize : size) (rng : rng) (num : i32) : (rng, [num]i32) =
+    let rngs =
+      r.split_rng num rng
+    let (rngs, sizes) =
+      unzip (map (\rng -> rand_i32 (0,maxsize) rng) rngs)
+    in (r.join_rng rngs, sizes)
 
 }

--- a/tests/hillis_steele.fut
+++ b/tests/hillis_steele.fut
@@ -4,9 +4,8 @@ open Fucheck
 let ilog2 (x: i32) = 31 - i32.clz x
 
 let hillis_steele [n] (xs: [n]i32) : [n]i32 =
-  unsafe
   let m = ilog2 n in
-  loop xs = copy xs for d in (0...m) do
+  loop xs = copy xs for d in (0...i32.max 0 m) do
     let ofs = 2 ** d in
     map3 (\i1 xr x -> if i1 < ofs then x else x + xr) (iota n) (rotate (-ofs) xs) xs
 
@@ -16,17 +15,13 @@ let main (s: []i32) : []i32 =
 -- testing with fucheck begins here
 
 -- fucheck hillis
-let gen_hillis (size : i32) (seed : i32) : testdata ([]i32) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
+let gen_hillis : gen ([]i32) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
   let arrgen = arbitraryarr arbitraryi32 <| i32.max 0 <| ilog2 sizes[0]
-  in arrgen size rngs[1]
+  in arrgen size rng
 
-let prop_hillis (input : testdata ([]i32)) : bool =
-  match input
-  case #testdata arr ->
-    scan (+) 0 arr == hillis_steele arr
+let prop_hillis (arr : []i32) : bool =
+  scan (+) 0 arr == hillis_steele arr
 
-let show_hillis (input : testdata ([]i32)) : []u8 =
+let show_hillis (input : []i32) : []u8 =
   show_array showdecimali32 input
-

--- a/tests/process-idx.fut
+++ b/tests/process-idx.fut
@@ -16,20 +16,16 @@ let fst (a,_) = a
 
 -- fucheck proc
 let gen_proc = process_gen
-let prop_proc [n] (input : testdata ([n]i32, [n]i32)) : bool =
-  match input
-  case #testdata (arr0,arr1) -> process arr0 arr1 == fst (process_idx arr0 arr1)
+let prop_proc [n] ((arr0,arr1) : ([n]i32, [n]i32)) : bool =
+  process arr0 arr1 == fst (process_idx arr0 arr1)
 
 let show_proc = process_show
 
 -- fucheck idx
 let gen_idx = process_gen
-let prop_idx [n] (input : testdata ([n]i32, [n]i32)) : bool =
-  match input
-  case #testdata (arr0,arr1) ->
-    let (diff,idx) = process_idx arr0 arr1
-    let idx_diff = if n == 0 then 0 else i32.abs (arr0[idx] - arr1[idx])
-    --let idx_diff = (arr0[idx] - arr1[idx])
-    in diff == idx_diff
+let prop_idx [n] ((arr0,arr1) : ([n]i32, [n]i32)) : bool =
+  let (diff,idx) = process_idx arr0 arr1
+  let idx_diff = if n == 0 then 0 else i32.abs (arr0[idx] - arr1[idx])
+  in diff == idx_diff
 
 let show_idx = process_show

--- a/tests/process.fut
+++ b/tests/process.fut
@@ -4,14 +4,12 @@ open Fucheck
 let process (s1: []i32) (s2: []i32): i32 =
   reduce i32.max 0 (map i32.abs (map2 (-) s1 s2))
 
-let process_gen (size : size) (seed : i32) : testdata ([]i32, []i32) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
-  let arrgen = (arbitraryarr arbitraryi32 sizes[0])
-  in arbitrarytuple arrgen arrgen size rngs[1]
+let process_gen : gen ([](i32, i32)) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
+  in arbitraryarr (arbitrarytuple arbitraryi32 arbitraryi32) sizes[0] size rng
 
-let process_show [n] (input : testdata ([n]i32, [n]i32)) : []u8 =
-    showtuple (show_array showdecimali32) (show_array showdecimali32) input
+let process_show [n] (input : [n](i32, i32)) : []u8 =
+  showtuple (show_array showdecimali32) (show_array showdecimali32) (unzip input)
 
 let main (s1: []i32) (s2: []i32) : i32 =
   process s1 s2
@@ -20,26 +18,25 @@ let main (s1: []i32) (s2: []i32) : i32 =
 
 -- fucheck proc_comm
 let gen_proc_comm = process_gen
-let prop_proc_comm [n] (input : testdata ([n]i32, [n]i32)) : bool =
-  match input
-  case #testdata (arr0,arr1) -> process arr0 arr1 == process arr1 arr0
+let prop_proc_comm [n] (arr : ([n](i32, i32))) : bool =
+  let (arr0,arr1) = unzip arr
+  in process arr0 arr1 == process arr1 arr0
 
 -- fucheck proc_neg
 let gen_proc_neg = process_gen
-let prop_proc_neg [n] (input : testdata ([n]i32, [n]i32)) : bool =
-  match input
-  case #testdata (arr0,arr1) -> process (map (0-) arr0) arr1 == process arr1 (map (0-) arr0)
+let prop_proc_neg [n] (arr : [n](i32, i32)) : bool =
+  let (arr0,arr1) = unzip arr
+  in process (map (0-) arr0) arr1 == process arr1 (map (0-) arr0)
 
 -- fucheck proc_maxdiff
 let gen_proc_maxdiff = process_gen
-let prop_proc_maxdiff [n] (input : testdata ([n]i32, [n]i32)) : bool =
-  match input
-  case #testdata (arr0,arr1) ->
-    let mx = i32.max (reduce i32.max i32.lowest arr0) (reduce i32.max i32.lowest arr1)
-    let mn = i32.min (reduce i32.min i32.highest arr0) (reduce i32.min i32.highest arr1)
-    let m_diff = mx - mn
-    let processed = process arr0 arr1
-    in m_diff >= processed
+let prop_proc_maxdiff [n] (arr : [n](i32, i32)) : bool =
+  let (arr0,arr1) = unzip arr
+  let mx = i32.max (reduce i32.max i32.lowest arr0) (reduce i32.max i32.lowest arr1)
+  let mn = i32.min (reduce i32.min i32.highest arr0) (reduce i32.min i32.highest arr1)
+  let m_diff = mx - mn
+  let processed = process arr0 arr1
+  in m_diff >= processed
 
 let show_proc_maxdiff = process_show
 

--- a/tests/segreduce.fut
+++ b/tests/segreduce.fut
@@ -1,4 +1,4 @@
-import "/home/sigurd/studie/bachelor/fucheck/src/futs/fucheck"
+import "../src/futs/fucheck"
 open Fucheck
 
 let segscan [n] 't (op: t -> t -> t) (ne: t) (arr: [n](t, bool)) : [n]t =
@@ -38,35 +38,31 @@ let fixfirst a =
   let b = copy a
   in b with [0] = (fst a[0],true)
 
-let prop [n] (input : testdata ([n](i32,bool))) : bool =
-  match input
-  case #testdata arr ->
-    let a = crude_segreduce (+) 0 arr
-    let b = segreduce (+) 0 arr
-    let la = length a
-    in if la == length b then
-         (a :> [la]i32) == (b :>[la]i32)
-       else false
+let prop [n] (arr : [n](i32,bool)) : bool =
+  let a = crude_segreduce (+) 0 arr
+  let b = segreduce (+) 0 arr
+  let la = length a
+  in if la == length b then
+       (a :> [la]i32) == (b :>[la]i32)
+     else false
 
-let show [n] (input : testdata ([n](i32,bool))) : []u8 =
+let show [n] (input : [n](i32,bool)) : []u8 =
   show_array (showtuple showdecimali32 showbool) input
 
 -- fucheck segreduce
-let gen_segreduce (size : i32) (seed : i32) : testdata ([](i32,bool)) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
+let gen_segreduce : gen ([](i32,bool)) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
   let arrgen = arbitraryarr (arbitrarytuple arbitraryi32 arbitrarybool) sizes[0]
-  in (transformgen fixfirst arrgen) size rngs[1]
+  in (transformgen fixfirst arrgen) size rng
 
 let prop_segreduce = prop
 let show_segreduce = show
 
 -- fucheck segreduce_undefined
-let gen_segreduce_undefined (size : i32) (seed : i32) : testdata ([](i32,bool)) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
+let gen_segreduce_undefined : gen ([](i32,bool)) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
   let arrgen = arbitraryarr (arbitrarytuple arbitraryi32 arbitrarybool) sizes[0]
-  in arrgen size rngs[1]
+  in arrgen size rng
 
 let prop_segreduce_undefined = prop
 let show_segreduce_undefined = show

--- a/tests/segscan.fut
+++ b/tests/segscan.fut
@@ -1,4 +1,4 @@
-import "/home/sigurd/studie/bachelor/fucheck/src/futs/fucheck"
+import "../src/futs//fucheck"
 open Fucheck
 
 let segscan [n] 't (op: t -> t -> t) (ne: t) (arr: [n](t, bool)) : [n]t =
@@ -28,16 +28,13 @@ let crude_segscan [n] (op: i32 -> i32 -> i32) (ne: i32) (arr: [n](i32,bool)) : [
   in result :> [n]i32
 
 -- fucheck segscan
-let gen_segscan (size : i32) (seed : i32) : testdata ([](i32,bool)) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
+let gen_segscan : gen ([](i32,bool)) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
   let arrgen = arbitraryarr (arbitrarytuple arbitraryi32 arbitrarybool) sizes[0]
-  in arrgen size rngs[1]
+  in arrgen size rng
 
-let prop_segscan [n] (input : testdata ([n](i32,bool))) : bool =
-  match input
-  case #testdata arr ->
-    crude_segscan (+) 0 arr == segscan (+) 0 arr
+let prop_segscan [n] (arr : ([n](i32,bool))) : bool =
+  crude_segscan (+) 0 arr == segscan (+) 0 arr
 
-let show_segscan [n] (input : testdata ([n](i32,bool))) : []u8 =
+let show_segscan [n] (input : ([n](i32,bool))) : []u8 =
   show_array (showtuple showdecimali32 showbool) input

--- a/tests/tests.fut
+++ b/tests/tests.fut
@@ -1,4 +1,4 @@
-import "/home/sigurd/studie/bachelor/fucheck/src/futs/fucheck"
+import "../src/futs//fucheck"
 open Fucheck
 
 
@@ -38,7 +38,7 @@ entry show_tupleMightFail = show2tuple showdecimali32 showdecimali32
 -- fucheck bool
 entry gen_bool = arbitrarybool
 
-entry prop_bool b = b
+entry prop_bool b = b : bool
 
 entry show_bool = showbool
 
@@ -62,16 +62,16 @@ entry labels_cond ((i,j): (i32,i32)) : []u8 =
 
 
 -- fucheck zip 1
-let gen_zip arrsize size rng : ([arrsize]i32, [arrsize]i32) =
-    let my_arb = (arbitraryarr arbitraryi32 arrsize)
-    in arbitrarytuple my_arb my_arb size rng
+let gen_zip arrsize : gen ([arrsize]i32, [arrsize]i32) = \size rng ->
+  let my_arb = (arbitraryarr arbitraryi32 arrsize)
+  in arbitrarytuple my_arb my_arb size rng
 
 entry prop_zip [n] ((as,bs) : ([n]i32,[n]i32)) : bool =
    (as,bs) == unzip (zip as bs)
 
 -- fucheck transpose 2
-entry gen_transpose arrsize0 arrsize1 size rng : [arrsize0][arrsize1]i32 =
-    scale (10+) (arbitrary2darr arbitraryi32 arrsize0 arrsize1) size rng
+entry gen_transpose arrsize0 arrsize1 : gen ([arrsize0][arrsize1]i32) = \size rng ->
+  scale (10+) (arbitrary2darr arbitraryi32 arrsize0 arrsize1) size rng
 
 entry prop_transpose [n] [m] (matrix : [n][m]i32) : bool =
   matrix == transpose (transpose matrix)

--- a/tests/work_efficient.fut
+++ b/tests/work_efficient.fut
@@ -1,10 +1,9 @@
-import "/home/sigurd/studie/bachelor/fucheck/src/futs/fucheck"
+import "../src/futs//fucheck"
 open Fucheck
 
 let ilog2 (x: i32) = 31 - i32.clz x
 
 let work_efficient [n] (xs: [n]i32) : [n]i32 =
-  unsafe
   let m = ilog2 n
   let upswept =
     loop xs = copy xs for d in (m-1..m-2...0) do
@@ -37,27 +36,24 @@ let main (s: []i32) : []i32 =
 
 -- testing with fucheck begins here
 
-let show (input : testdata ([]i32)) : []u8 =
+let show (input : ([]i32)) : []u8 =
   show_array showdecimali32 input
 
-let prop (input : testdata ([]i32)) : bool =
-  match input
-  case #testdata arr ->
-    scan (+) 0 arr ==  work_efficient arr
+let prop (arr : ([]i32)) : bool =
+  scan (+) 0 arr ==  work_efficient arr
 
 -- fucheck non_zero_arr
-let gen_non_zero_arr (size : i32) (seed : i32) : testdata ([]i32) =
-  let rngs = split_rng 2 <| rng_from_seed seed
-  let sizes = getsizes size rngs[0] 1
+let gen_non_zero_arr : gen ([]i32) = \size rng ->
+  let (rng, sizes) = getsizes size rng 1
   let arrgen = arbitraryarr arbitraryi32 <| 2 ** (ilog2 0 + 1)
-  in arrgen size rngs[1]
+  in arrgen sizes[0] rng
 
 let prop_non_zero_arr = prop
 
 let show_non_zero_arr = show
 
 -- fucheck with_zero_arr
-let gen_with_zero_arr (_ : i32) (_ : i32) : testdata ([]i32) = testdata []
+let gen_with_zero_arr (_ : i32) (_ : i32) : ([]i32) = []
 
 let prop_with_zero_arr = prop
 


### PR DESCRIPTION
This is both better and faster than using split_rng so often.

Also fixes most of the tests to actually type-check (although fucheck
may still fail on them).